### PR TITLE
Add backward compatibility for Hyprland (<0.54.0) and improve rending

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,13 @@ add_library(${PROJECT_NAME} SHARED ${SRC})
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(hyprland REQUIRED IMPORTED_TARGET hyprland)
 
+if(hyprland_VERSION VERSION_GREATER_EQUAL "0.54.0")
+  message(STATUS "Hyprland >= 0.54.0 detected — using new EventBus API")
+  target_compile_definitions(${PROJECT_NAME} PRIVATE HYPRLAND_NEW_EVENTS)
+else()
+  message(STATUS "Hyprland < 0.54.0 detected — using legacy HookSystem API")
+endif()
+
 if(ENABLE_PROTOCOLS)
   pkg_check_modules(hyprwire REQUIRED IMPORTED_TARGET hyprwire)
 endif()

--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,7 @@ install:
 	cp build/$(TARGET).so ~/.config/hypr/plugins/$(TARGET).so
 	hyprctl plugin load ~/.config/hypr/plugins/$(TARGET).so
 
-.PHONY: all release run trace debug
+clean:
+	rm -rf $(BUILD_DIR)
+
+.PHONY: all release run trace debug clean

--- a/src/container.cpp
+++ b/src/container.cpp
@@ -7,11 +7,23 @@
 #include <src/render/Renderer.hpp>
 
 WindowCard::WindowCard(PHLWINDOW window) : window(window) {
+#ifdef HYPRLAND_NEW_EVENTS
   commit = window->wlSurface()->resource()->m_events.commit.listen([this] {
     needsSnapshot = true;
     ready = false;
     lastCommit = NOW;
   });
+#else
+  commit = HyprlandAPI::registerCallbackDynamic(PHANDLE, "commit",
+                                                [this](void *self, SCallbackInfo &info, std::any data) {
+                                                  auto committedWindow = std::any_cast<PHLWINDOW>(data);
+                                                  if (committedWindow != this->window)
+                                                    return;
+                                                  needsSnapshot = true;
+                                                  ready = false;
+                                                  lastCommit = NOW;
+                                                });
+#endif
   borderColor = CGradientValueData(Colors::YELLOW);
 }
 

--- a/src/container.hpp
+++ b/src/container.hpp
@@ -39,5 +39,9 @@ private:
   std::string title;
   SP<CTexture> titleTexture;
   double lastWidth = 0;
+#ifdef HYPRLAND_NEW_EVENTS
   CHyprSignalListener commit;
+#else
+  SP<HOOK_CALLBACK_FN> commit;
+#endif
 };

--- a/src/defines.hpp
+++ b/src/defines.hpp
@@ -2,11 +2,14 @@
 #include "logger.hpp"
 #include <src/config/ConfigDataValues.hpp>
 #include <src/desktop/DesktopTypes.hpp>
+#ifdef HYPRLAND_NEW_EVENTS
 #include <src/event/EventBus.hpp>
+#define HOOK_EVENT(PATH, LAMBDA) Event::bus()->m_events.PATH.listen(LAMBDA);
+#else
+#include <src/plugins/HookSystem.hpp>
+#endif
 #include <src/helpers/Color.hpp>
 #include <src/plugins/PluginAPI.hpp>
-
-#define HOOK_EVENT(PATH, LAMBDA) Event::bus()->m_events.PATH.listen(LAMBDA);
 
 inline HANDLE PHANDLE = nullptr;
 

--- a/src/manager.cpp
+++ b/src/manager.cpp
@@ -20,6 +20,7 @@ static int lastCounter = 0;
 
 Manager::Manager() {
   LOG_SCOPE()
+#ifdef HYPRLAND_NEW_EVENTS
   listeners.config = HOOK_EVENT(config.reloaded, [this]() {
     onConfigReload();
   });
@@ -41,6 +42,22 @@ Manager::Manager() {
   listeners.monitorRemoved = HOOK_EVENT(monitor.removed, [this](auto m) {
     rebuild();
   });
+#else
+  listeners.config = HyprlandAPI::registerCallbackDynamic(PHANDLE, "configReloaded",
+                                                          [this](void *self, SCallbackInfo &info, std::any data) { onConfigReload(); });
+  listeners.windowCreated = HyprlandAPI::registerCallbackDynamic(PHANDLE, "openWindow",
+                                                                 [this](void *self, SCallbackInfo &info, std::any data) { onWindowCreated(std::any_cast<PHLWINDOW>(data)); });
+  listeners.windowDestroyed = HyprlandAPI::registerCallbackDynamic(PHANDLE, "closeWindow",
+                                                                   [this](void *self, SCallbackInfo &info, std::any data) { onWindowDestroyed(std::any_cast<PHLWINDOW>(data)); });
+  listeners.render = HyprlandAPI::registerCallbackDynamic(PHANDLE, "render",
+                                                          [this](void *self, SCallbackInfo &info, std::any data) { onRender(std::any_cast<eRenderStage>(data)); });
+  listeners.focusChange = HyprlandAPI::registerCallbackDynamic(PHANDLE, "monitorFocusChange",
+                                                               [this](void *self, SCallbackInfo &info, std::any data) { onFocusChange(std::any_cast<PHLMONITOR>(data)); });
+  listeners.monitorAdded = HyprlandAPI::registerCallbackDynamic(PHANDLE, "monitorAdded",
+                                                                [this](void *self, SCallbackInfo &info, std::any data) { rebuild(); });
+  listeners.monitorRemoved = HyprlandAPI::registerCallbackDynamic(PHANDLE, "monitorRemoved",
+                                                                  [this](void *self, SCallbackInfo &info, std::any data) { rebuild(); });
+#endif
 
   lastFrame = lastUpdate = NOW;
 }
@@ -79,7 +96,11 @@ void Manager::confirm() {
   auto selected = mon->windows[mon->activeWindow]->window;
   if (BRINGTOACTIVE)
     g_pKeybindManager->m_dispatchers["focusworkspaceoncurrentmonitor"](selected->m_workspace->m_name);
+#ifdef HYPRLAND_NEW_EVENTS
   Desktop::focusState()->fullWindowFocus(selected, Desktop::FOCUS_REASON_KEYBIND);
+#else
+  Desktop::focusState()->fullWindowFocus(selected);
+#endif
   deactivate();
 }
 
@@ -119,7 +140,8 @@ void Manager::draw(MONITORID monid, const CRegion &damage) {
   auto dmg = damage;
 
   if (!POWERSAVE) {
-    g_pHyprOpenGL->renderRect(dmg.getExtents(), CHyprColor(0.0, 0.0, 0.0, (DIMENABLED) ? DIMAMOUNT : 0), {.blur = sc<bool>(BLURBG)});
+    CBox monBox = {{0, 0}, cur->m_pixelSize};
+    g_pHyprOpenGL->renderRect(monBox, CHyprColor(0.0, 0.0, 0.0, (DIMENABLED) ? DIMAMOUNT : 0), {.blur = sc<bool>(BLURBG)});
   } else {
     if (monitors.contains(monid))
       monitors[monid]->renderTexture(damage);
@@ -160,8 +182,12 @@ void Manager::draw(MONITORID monid, const CRegion &damage) {
       Overlay->add(std::format("monitor->m_size.x: {}, monitor->m_size.y: {}\nmonitor->m_pixelSize.x: {}, monitor->m_pixelSize.y: {}", monitors[activeMonitor]->monitor->m_size.x, monitors[activeMonitor]->monitor->m_size.y, monitors[activeMonitor]->monitor->m_size.x, monitors[activeMonitor]->monitor->m_size.y));
 #endif
     }
-    if (monitors[activeMonitor]->animating)
+    bool isMonitorAnimating = !monitorOffset.done();
+    if (monitors[activeMonitor]->animating || isMonitorAnimating)
       g_pCompositor->scheduleFrameForMonitor(monitors[activeMonitor]->monitor);
+
+    if (isMonitorAnimating && !POWERSAVE)
+      g_pHyprRenderer->damageMonitor(cur);
   }
 
 #ifndef NDEBUG

--- a/src/manager.hpp
+++ b/src/manager.hpp
@@ -29,6 +29,7 @@ private:
   void onRender(eRenderStage stage);
   void onFocusChange(PHLMONITOR monitor);
 
+#ifdef HYPRLAND_NEW_EVENTS
   struct {
     CHyprSignalListener config;
     CHyprSignalListener windowCreated;
@@ -38,6 +39,17 @@ private:
     CHyprSignalListener monitorAdded;
     CHyprSignalListener monitorRemoved;
   } listeners;
+#else
+  struct {
+    SP<HOOK_CALLBACK_FN> config;
+    SP<HOOK_CALLBACK_FN> windowCreated;
+    SP<HOOK_CALLBACK_FN> windowDestroyed;
+    SP<HOOK_CALLBACK_FN> render;
+    SP<HOOK_CALLBACK_FN> focusChange;
+    SP<HOOK_CALLBACK_FN> monitorAdded;
+    SP<HOOK_CALLBACK_FN> monitorRemoved;
+  } listeners;
+#endif
 
   MONITORID activeMonitor = MONITOR_INVALID;
   Timestamp lastFrame;
@@ -51,7 +63,7 @@ inline UP<Manager> manager;
 class RenderPass : public IPassElement {
 public:
   virtual void draw(const CRegion &damage);
-  virtual bool needsLiveBlur() { return false; }
+  virtual bool needsLiveBlur() { return BLURBG && !POWERSAVE; }
   virtual bool needsPrecomputeBlur() { return false; }
   virtual const char *passName() { return "TabCarouselPassElement"; }
 };

--- a/src/monitor.cpp
+++ b/src/monitor.cpp
@@ -185,10 +185,14 @@ void Monitor::draw(const CRegion &damage, const float &offset = 0.0f, const bool
     g_pHyprOpenGL->renderRect(dmg.getExtents(), {0.5, 0.5, 0.0, 0.5}, {});
 #endif
   if (animating) {
-    if (POWERSAVE)
-      monitor->addDamage(dmg);
-    else
+    if (POWERSAVE) {
+      CRegion totalDamage = dmg;
+      totalDamage.add(lastDamage);
+      monitor->addDamage(totalDamage);
+      lastDamage = dmg;
+    } else {
       g_pHyprRenderer->damageMonitor(monitor);
+    }
   }
 }
 

--- a/src/monitor.hpp
+++ b/src/monitor.hpp
@@ -25,6 +25,7 @@ public:
   PHLWINDOW select(int card);
 
   bool animating = false;
+  CRegion lastDamage;
   AnimatedValue<float> rotation;
   AnimatedValue<float> zoom;
   AnimatedValue<float> alpha;


### PR DESCRIPTION
My attempt to Add backward compatibility for hyprland and fix #4
Why? 
Manjaro is still on Hyprland 0.53.3 and hasn't received the latest updates yet. To avoid breaking the plugin for users on stable/delayed branches, this setup uses a compile-time condition to determine the Hyprland version.

What's changed:
Implemented Dual-Track Hooks so the plugin works seamlessly on both Hyprland 0.54.0 and 0.53.x.
Added a make clean target to the Makefile.
Kept the original codebase as untouched as possible, strictly adding only what was necessary for the compatibility wrappers and the rendering fixes for #4

Tested on:
OS: Linux 6.12.73-1-MANJARO
WM: Hyprland 0.53.3





