### PR TITLE
Fix missing Transformer.hpp include path for Hyprland 0.55

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ compile_commands.json
 /hl.conf
 /alttab.so
 /Session.vim
+hyprland-notes

--- a/src/manager.hpp
+++ b/src/manager.hpp
@@ -7,7 +7,7 @@
 #include <src/helpers/time/Timer.hpp>
 #include <src/managers/eventLoop/EventLoopTimer.hpp>
 #include <src/render/Texture.hpp>
-#include <src/render/transformer/Transformer.hpp>
+#include <src/render/Transformer.hpp>
 #include <src/render/pass/PassElement.hpp>
 #include <src/render/pass/SurfacePassElement.hpp>
 


### PR DESCRIPTION
Small fix :

```logs
❯ sudo make release
cmake -B build -S . -DCMAKE_BUILD_TYPE=Release
-- The C compiler identification is GNU 16.1.1
-- The CXX compiler identification is GNU 16.1.1
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Protocols disabled
-- Found PkgConfig: /usr/bin/pkg-config (found version "2.5.1")
-- Checking for module 'hyprland'
--   Found hyprland, version 0.55.4
-- Hyprland >= 0.54.0 detected — using new EventBus API
-- Linked compile_commands.json to project root
-- Configuring done (0.8s)
-- Generating done (0.0s)
-- Build files have been written to: /home/aayanopal/GitCrubs/alttab/build
cmake --build build -j4
make[1]: Entering directory '/home/aayanopal/GitCrubs/alttab/build'
[ 42%] Building CXX object CMakeFiles/alttab.dir/src/manager.cpp.o
[ 42%] Building CXX object CMakeFiles/alttab.dir/src/main.cpp.o
[ 42%] Building CXX object CMakeFiles/alttab.dir/src/container.cpp.o
[ 57%] Building CXX object CMakeFiles/alttab.dir/src/logger.cpp.o
[ 71%] Building CXX object CMakeFiles/alttab.dir/src/monitor.cpp.o
[ 85%] Building CXX object CMakeFiles/alttab.dir/src/styles.cpp.o
[100%] Linking CXX shared library alttab.so
[100%] Built target alttab
make[1]: Leaving directory '/home/aayanopal/GitCrubs/alttab/build'
cp build/alttab.so .
❯ hyprctl plugin load /home/aayanopal/GitCrubs/alttab/alttab.so
```

It works